### PR TITLE
Fixed video player blobType for .MOV files

### DIFF
--- a/public/serviceWorker.js
+++ b/public/serviceWorker.js
@@ -2398,7 +2398,7 @@ async function unpackFile() {
                                     activeSpannedJob.progress = `100%`;
                                     let blobType = {}
                                     if (activeSpannedJob.play === 'video' || activeSpannedJob.play === 'kms-video' || videoFiles.indexOf(activeSpannedJob.filename.split('.').pop().toLowerCase().trim()) > -1)
-                                        blobType.type = 'video/' + activeSpannedJob.filename.split('.').pop().toLowerCase().trim();
+                                        blobType.type = 'video/' + (activeSpannedJob.filename.toLowerCase().includes('.mov') ? "mp4" : activeSpannedJob.filename.split('.').pop().toLowerCase().trim());
                                     if (activeSpannedJob.play === 'audio' || audioFiles.indexOf(activeSpannedJob.filename.split('.').pop().toLowerCase().trim()) > -1)
                                         blobType.type = 'audio/' + activeSpannedJob.filename.split('.').pop().toLowerCase().trim();
 


### PR DESCRIPTION
HTML audio and video does not support QuickTime, and it's unlikely that any incoming .MOV files are automatically QuickTime, so this is the best solution (afaik) short of reading the file header.

Logically, this should be all that is needed, but I was having trouble testing this. Definitely give it a try before committing, as JS is not the language I'm most comfortable with.