### PR TITLE
Added volume saving to FancyBox

### DIFF
--- a/public/static/js/jquery.fancybox.js
+++ b/public/static/js/jquery.fancybox.js
@@ -2165,6 +2165,14 @@
       if ($(content).is("video,audio")) {
         $(content).addClass("fancybox-video");
 
+        let vid = $(content)[0];
+        
+        $(content)[0].onvolumechange = function() {
+          setCookie("userVolume", vid.volume)
+        }
+        
+        $(content)[0].volume = (getCookie("userVolume") !== null) ? parseFloat(getCookie("userVolume")) : 0.5
+
         $(content).wrap("<div></div>");
 
         slide.contentType = "video";


### PR DESCRIPTION
Uses the existing "userVolume" cookie, and sets it on adjustment (which isn't the most ideal, but onclose doesn't get called when moving between items in the slideshow)