### PR TITLE
Impose a character limit on server names to prevent overflow

### DIFF
--- a/views/init-layout.pug
+++ b/views/init-layout.pug
@@ -855,7 +855,7 @@ html
                                     div.mr-3
                                         img.rounded-pill(src=thisServer.icon style='height: 8em;')
                                     div
-                                        h2.mb-1 #{(thisServer.nice_name) ? thisServer.nice_name : thisServer.name} (#{thisServer.short_name.toUpperCase()})
+                                        h2.mb-1 #{(thisServer.nice_name) ? thisServer.nice_name : (thisServer.name.length > 17 ? (thisServer.name.slice(0, 17) + "...") : thisServer.name)} (#{thisServer.short_name.toUpperCase()})
                                         if (thisServer.nice_name && thisServer.name && thisServer.nice_name.toLowerCase() !== thisServer.name.toLowerCase())
                                             h5 #{thisServer.name}
                                         div.d-inline.text-lg


### PR DESCRIPTION
I believe this little ternary should prevent names from wrapping down below the server images. The length might need adjusting, but worked okay in my testing.

Note that this does not affect nice names, which should probably already be the right length to display.